### PR TITLE
Bug: Update is never called, if loop iterates faster than frame length.

### DIFF
--- a/Game/GameLoopTest.cs
+++ b/Game/GameLoopTest.cs
@@ -132,5 +132,43 @@ namespace MyGame
 			Assert.AreEqual(2, game.UpdateCount);
 			Assert.AreEqual(1, game.DrawCount);
 		}
+
+		[Test]
+		public void ItSkipsUpdateToSlowGameProgressWhenTheLagIsTooSmall() {
+			var game = new TestGame();
+			game.EnqueRunningAnswers(true, false);
+			var time = new SecondTicker();
+
+			var gameLoop = new GameLoop {
+				Game = game,
+				InputHandler = new NullInputHandler(),
+				Timer = time, 
+				FrameLength = 2
+			};
+
+			gameLoop.Run();
+
+			Assert.AreEqual(0, game.UpdateCount);
+			Assert.AreEqual(1, game.DrawCount);
+		}
+
+		[Test]
+		public void ItRunsUpdateEventually() {
+			var game = new TestGame();
+			game.EnqueRunningAnswers(true, true, true, true, false);
+			var time = new SecondTicker();
+
+			var gameLoop = new GameLoop {
+				Game = game,
+				InputHandler = new NullInputHandler(),
+				Timer = time, 
+				FrameLength = 2
+			};
+
+			gameLoop.Run();
+
+			Assert.AreEqual(1, game.UpdateCount);
+			Assert.AreEqual(4, game.DrawCount);
+		}
 	}
 }

--- a/Game/TestGame.cs
+++ b/Game/TestGame.cs
@@ -40,8 +40,8 @@ namespace MyGame
 
 		public void Draw()
 		{
-			if (DrawCount > UpdateCount)
-				throw new InvalidDrawException();
+			//if (DrawCount > UpdateCount)
+			//	throw new InvalidDrawException();
 
 			DrawCount++;
 		}


### PR DESCRIPTION
There's two test cases I think should pass, but currently don't. The first fails, because of the check DrawCount > UpdateCount in your test stub, which I've commented out. The second fails, because your code doesn't handle this scenario (the pseudo code from you blog post does).
